### PR TITLE
Add autocommit switch

### DIFF
--- a/postgres_kernel.egg-info/PKG-INFO
+++ b/postgres_kernel.egg-info/PKG-INFO
@@ -6,7 +6,6 @@ Home-page: https://github.com/bgschiller/postgres_kernel
 Author: Brian Schiller
 Author-email: bgschiller@gmail.com
 License: UNKNOWN
-Description-Content-Type: UNKNOWN
 Description: A simple Jupyter kernel for PostgreSQL
         
         I don't know how to set this up to be pip-installable, but maybe you can help with that?

--- a/postgres_kernel/kernel.py
+++ b/postgres_kernel/kernel.py
@@ -133,8 +133,8 @@ class PostgresKernel(Kernel):
             self.iopub_socket, 'stream', {
                 'name': 'stdout',
                 'text': (
-                    f'commited current transaction & switched autocommit mode to '
-                    f'{str(self._conn.autocommit)}'
+                    'commited current transaction & switched autocommit mode to ' +
+                    str(self._conn.autocommit)
                     )
                 }
             )


### PR DESCRIPTION
adds `AUTOCOMMIT_SWITCH` which detects user input after `--autocommit:`. Commits the current transaction and then sets autocommit to true or false (case insensitive). Throws descriptive error if input is incorrect.